### PR TITLE
Don't overload `Flp.encode()`

### DIFF
--- a/poc/flp_pine.py
+++ b/poc/flp_pine.py
@@ -283,7 +283,7 @@ class PineValid(Valid):
             s += self.GADGETS[0].eval(self.Field, chunk)
         return s
 
-    def encode(self, measurement: Measurement) -> list[Field]:
+    def encode_gradient(self, measurement):
         """
         Encode everything except wraparound check results:
         - Encode each f64 value into field element.
@@ -308,9 +308,7 @@ class PineValid(Valid):
         )
         return encoded
 
-    def wr_check_dot_prod(self,
-                          encoded_gradient: list[Field],
-                          wr_joint_rand_xof: Xof) -> list[Field]:
+    def run_wr_checks(self, encoded_gradient, wr_joint_rand_xof):
         """
         Compute the dot products of `encoded_gradient` with the wraparound
         joint randomness, sampled from the XOF `wr_joint_rand_xof`. `eval()`
@@ -348,10 +346,7 @@ class PineValid(Valid):
             wr_dot_prods[wr_check_index] += rand_field * x
         return wr_dot_prods
 
-    def run_wr_checks(self,
-                      encoded_gradient: list[Field],
-                      wr_joint_rand_xof: Xof) -> tuple[list[Field],
-                                                       list[Field]]:
+    def encode_wr_checks(self, encoded_gradient, wr_joint_rand_xof):
         """
         Run the wraparound checks and return the dot product for each check
         (`wr_dot_prods`) and the range-checked result for each check
@@ -366,7 +361,7 @@ class PineValid(Valid):
         # wraparound joint randomness field elements in each wraparound check,
         # sampled from the XOF `wr_joint_rand_xof`.
         wr_dot_prods = \
-            self.wr_check_dot_prod(encoded_gradient, wr_joint_rand_xof)
+            self.run_wr_checks(encoded_gradient, wr_joint_rand_xof)
 
         # Stores wraparound check result bits, and success bits.
         wr_check_bits = []

--- a/poc/flp_pine_test.py
+++ b/poc/flp_pine_test.py
@@ -76,7 +76,7 @@ class TestEncoding(unittest.TestCase):
         valid = PineValid.with_field(Field128)(1.0, 15, 2, 1)
         f64_vals = [0.5, 0.5]
         self.assertEqual(f64_vals,
-                         valid.decode(valid.truncate(valid.encode(f64_vals)), 1))
+                         valid.decode(valid.truncate(valid.encode_gradient(f64_vals)), 1))
 
 
 class TestCircuit(unittest.TestCase):
@@ -117,9 +117,8 @@ class TestCircuit(unittest.TestCase):
 
             # Test PINE FLP with verification.
             xof = PineValid.Xof(gen_rand(16), b"", b"")
-            encoded_gradient = flp.encode(measurement)
-            (wr_check_bits, wr_dot_prods) = \
-                pine_valid.run_wr_checks(encoded_gradient, xof)
+            encoded_gradient = flp.Valid.encode_gradient(measurement)
+            (wr_check_bits, wr_dot_prods) = pine_valid.encode_wr_checks(encoded_gradient, xof)
             meas = encoded_gradient + wr_check_bits + wr_dot_prods
             test_flp_generic(flp, [(meas, True)])
 

--- a/poc/vdaf_pine.py
+++ b/poc/vdaf_pine.py
@@ -118,7 +118,7 @@ class Pine(Vdaf):
         l = Pine.Flp.Valid.Xof.SEED_SIZE
         seeds = [rand[i:i+l] for i in range(0, Pine.RAND_SIZE, l)]
 
-        encoded_gradient = Pine.Flp.encode(measurement)
+        encoded_gradient = Pine.Flp.Valid.encode_gradient(measurement)
         assert len(encoded_gradient) == Pine.Flp.Valid.encoded_gradient_len
 
         # Parse Helper seeds. Each Helper has 4 seeds:
@@ -183,7 +183,7 @@ class Pine(Vdaf):
         # randomness themselves, but the dot products are passed to
         # `Flp.Valid.eval()` later to avoid computing the dot products again.
         (wr_check_bits, wr_dot_prods) = \
-            Pine.Flp.Valid.run_wr_checks(encoded_gradient, wr_joint_rand_xof)
+            Pine.Flp.Valid.encode_wr_checks(encoded_gradient, wr_joint_rand_xof)
         encoded_measurement = encoded_gradient + wr_check_bits
         assert len(encoded_measurement) == Pine.MEAS_LEN
 
@@ -275,7 +275,6 @@ class Pine(Vdaf):
             Pine.joint_rand_part_and_seed_for_aggregator(
                 agg_id,
                 k_wr_joint_rand_blind,
-                # Use the output of `Pine.Flp.encode()`.
                 meas_share[:Pine.Flp.Valid.encoded_gradient_len],
                 nonce,
                 k_wr_joint_rand_parts,
@@ -286,8 +285,8 @@ class Pine(Vdaf):
         # compute the dot products in wraparound checks.
         wr_joint_rand_xof = \
             Pine.wr_joint_rand_xof(k_corrected_wr_joint_rand_seed)
-        wr_dot_prods = Pine.Flp.Valid.wr_check_dot_prod(meas_share,
-                                                        wr_joint_rand_xof)
+        wr_dot_prods = Pine.Flp.Valid.run_wr_checks(meas_share,
+                                                    wr_joint_rand_xof)
 
         # Compute this Aggregator's verification joint randomness part and seed.
         (k_vf_joint_rand_part, k_corrected_vf_joint_rand_seed) = \


### PR DESCRIPTION
Closes #43.

The output of this method is meant to be the input the `prove()` or `query()` algorithm, but in PIne, we have more encoding steps to do before we have the complete input.