### PR TITLE
Improvements to ZK error analysis script

### DIFF
--- a/poc/find_wr_params.sage
+++ b/poc/find_wr_params.sage
@@ -8,15 +8,17 @@
 # $ sage find_wr_params.sage
 # ```
 #
-# Methodology: Find pairs of `(r, tau)` that produce soundness error close to
-# the target (usually `2**64`), then find the smallest `eta` for which the ZK
-# error is close to `2**128`. The optimal set of parameters is the one that
+# Methodology: Find pairs of `(r, r_succ)` that produce soundness error close to
+# the target (usually `2**-64`), then find the smallest `eta` for which the ZK
+# error is close to `2**-128`. The optimal set of parameters is the one that
 # minimizes communication overhead, i.e., the number of field elements that we
 # need to encode the wraparound check results in the FLP input.
 
 dir_name = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.join(dir_name, "draft-irtf-cfrg-vdaf", "poc"))
 from common import next_power_of_2
+from field import Field64
+from flp_pine import PineValid
 
 def Bin(succ, total, prob):
     '''
@@ -26,31 +28,37 @@ def Bin(succ, total, prob):
     '''
     b = 0
     for k in range(succ, total+1):
-        b += binomial(total, k) * prob**k * (1-prob)**(total - k)
+        b += binomial(total, k) * prob**k * (1 - prob)**(total - k)
     return b
 
-def zk(r, tau, eta):
+def zk(r, r_succ, eta):
     '''$rho_C$ as defined in arxiv.org/abs/2311.10237, Lemma 3.3.'''
-    return 1 - Bin(r * tau, r, 1 - eta)
+    return 1 - Bin(r_succ, r, 1 - eta)
 
-def sound(r, tau):
+def sound(r, r_succ):
     '''$rho_S$ as defined in arxiv.org/abs/2311.10237, Lemma 3.3.'''
-    return Bin(r * tau, r, 1/2)
+    return Bin(r_succ, r, 1/2)
 
-def overhead(r, eta, l2_norm_bound, num_frac_bits):
+def overhead(r, r_succ, eta, l2_norm_bound, num_frac_bits):
     '''Number of field elements to encode wrap around tests.'''
-    alpha = ceil(sqrt(log(2/eta)))
-    l2_norm_bound_encoded = floor(l2_norm_bound * 2**num_frac_bits)
-    wr_check_bound = next_power_of_2(alpha * l2_norm_bound_encoded + 1) - 1
-    num_bits_for_wr_check = 1 + ceil(log(wr_check_bound + 1)/log(2))
-    return (r * (num_bits_for_wr_check + 1), alpha)
+    alpha = sqrt(log(2/eta))
+    pine_valid = PineValid.with_field(Field64)(
+        l2_norm_bound = l2_norm_bound,
+        num_frac_bits = num_frac_bits,
+        dimension = 100000,  # Doesn't change overhead from wraparound checks.
+        chunk_length = 100,  # Doesn't change overhead from wraparound checks.
+        alpha = alpha,
+        num_wr_checks = r,
+        num_wr_successes = r_succ
+    )
+    return (r * (pine_valid.num_bits_for_wr_check + 1), alpha)
 
 def bits_of_security(x):
     return floor(-log(x)/log(2))
 
 def search(target_soundness_bits):
     '''
-    Find values of `(r, tau)` with soundness error close to the target
+    Find values of `(r, r_succ)` with soundness error close to the target
     soundness (in bits of security). For example, `target_soundness_bits = 64`
     produces choices with soundness error close to `2**-64`.
     '''
@@ -58,10 +66,10 @@ def search(target_soundness_bits):
     failures = 0
     total = target_soundness_bits
     while failures < 16:
-        while bits_of_security(sound(total, (total - failures) / total)) \
+        while bits_of_security(sound(total, total - failures)) \
                 not in range(target_soundness_bits-1,target_soundness_bits+1):
             total += 1
-        params.append((total, (total - failures) / total, None))
+        params.append((total, total - failures, None))
         failures += 1
     return params
 
@@ -72,77 +80,98 @@ def display_params(params):
     complete the parameters, we run this on the output of `search()`, make an
     initial guess of `eta`, and manually tune until the desired ZK is reached.
     '''
-    for (r, tau, eta) in params:
+    col_widths = [10, 10, 15, 15, 15, 10, 20]
+    col_names = ["r",
+                 "r_succ",
+                 "-log2(eta)",
+                 "-log2(zk)",
+                 "-log2(sound)",
+                 "overhead",
+                 "alpha"]
+    headers = "|"
+    header_separator = "|"
+    for (col_name, col_width) in zip(col_names, col_widths):
+        headers += col_name.ljust(col_width) + "|"
+        header_separator += ":" + "-" * (col_width - 1) + "|"
+    print(headers)
+    print(header_separator)
+    for (r, r_succ, eta) in params:
         if eta != None:
-            print(r, tau, eta)
-            print('zk      ', bits_of_security(zk(r, tau, eta)))
-            print('sound   ', bits_of_security(sound(r, tau)))
-            print('overhead {} (alpha={})'.format(*overhead(r, eta, 1.0, 15)))
+            (num_elems, alpha) = overhead(r, r_succ, eta, 1.0, 15)
+            print("|{}|{}|{}|{}|{}|{}|{}|".format(
+                str(r).ljust(col_widths[0]),
+                str(r_succ).ljust(col_widths[1]),
+                str(bits_of_security(eta)).ljust(col_widths[2]),
+                str(bits_of_security(zk(r, r_succ, eta))).ljust(col_widths[3]),
+                str(bits_of_security(sound(r, r_succ))).ljust(col_widths[4]),
+                str(num_elems).ljust(col_widths[5]),
+                str(float(alpha)).ljust(col_widths[6]),
+            ))
     print()
 
 
 # print(search(32))
 params_32 = [
-    (32, 1, 2**-134),
-    (37, 36/37, 2**-69),
-    (41, 39/41, 2**-48),
-    (45, 14/15, None),
-    (49, 45/49, None),
-    (53, 48/53, None),
-    (57, 17/19, None),
-    (60, 53/60, None),
-    (64, 7/8, None),
-    (67, 58/67, None),
-    (70, 6/7, None),
-    (73, 62/73, None),
-    (77, 65/77, None),
-    (80, 67/80, None),
-    (83, 69/83, None),
-    (86, 71/86, 2**-12),
+    (32, 32, 2**-134),
+    (37, 36, 2**-69),
+    (41, 39, 2**-48),
+    (45, 42, None),
+    (49, 45, None),
+    (53, 48, None),
+    (57, 51, None),
+    (60, 53, None),
+    (64, 56, None),
+    (67, 58, None),
+    (70, 60, None),
+    (73, 62, None),
+    (77, 65, None),
+    (80, 67, None),
+    (83, 69, None),
+    (86, 71, 2**-12),
 ]
-print('------- 32')
+print('------- Target soundness error: 2^(-32)')
 display_params(params_32)
 
 # print(search(64))
 params_64 = [
-    (64, 1, 2**-134),
-    (70, 69/70, 2**-69),
-    (75, 73/75, 2**-48),
-    (80, 77/80, None),
-    (84, 20/21, None),
-    (89, 84/89, None),
-    (93, 29/31, None),
-    (97, 90/97, None),
-    (101, 93/101, 2**-19),
-    (105, 32/35, None),
-    (109, 99/109, None),
-    (113, 102/113, None),
-    (116, 26/29, None),
-    (120, 107/120, None),
-    (123, 109/123, None),
-    (127, 112/127, 2**-12),
+    (64, 64, 2**-134),
+    (70, 69, 2**-69),
+    (75, 73, 2**-48),
+    (80, 77, None),
+    (84, 80, None),
+    (89, 84, None),
+    (93, 87, None),
+    (97, 90, None),
+    (101, 93, 2**-19),
+    (105, 96, None),
+    (109, 99, None),
+    (113, 102, None),
+    (116, 104, None),
+    (120, 107, None),
+    (123, 109, None),
+    (127, 112, 2**-12),
 ]
-print('------- 64')
+print('------- Target soundness error: 2^(-64)')
 display_params(params_64)
 
 # print(search(80))
 params_80 = [
-    (80, 1, 2**-134),
-    (86, 85/86, 2**-69),
-    (92, 45/46, 2**-48),
-    (97, 94/97, None),
-    (102, 49/51, None),
-    (106, 101/106, None),
-    (111, 35/37, None),
-    (115, 108/115, None),
-    (119, 111/119, None),
-    (123, 38/41, None),
-    (127, 117/127, None),
-    (131, 120/131, None),
-    (135, 41/45, None),
-    (139, 126/139, None),
-    (142, 64/71, None),
-    (146, 131/146, 2**-12),
+    (80, 80, 2**-134),
+    (86, 85, 2**-69),
+    (92, 90, 2**-48),
+    (97, 94, None),
+    (102, 98, None),
+    (106, 101, None),
+    (111, 105, None),
+    (115, 108, None),
+    (119, 111, None),
+    (123, 114, None),
+    (127, 117, None),
+    (131, 120, None),
+    (135, 123, None),
+    (139, 126, None),
+    (142, 128, None),
+    (146, 131, 2**-12),
 ]
-print('------- 80')
+print('------- Target soundness error: 2^(-80)')
 display_params(params_80)

--- a/poc/flp_pine.py
+++ b/poc/flp_pine.py
@@ -37,7 +37,10 @@ class PineValid(Valid):
                  l2_norm_bound: float,
                  num_frac_bits: Unsigned,
                  dimension: Unsigned,
-                 chunk_length: Unsigned):
+                 chunk_length: Unsigned,
+                 alpha: float = ALPHA,
+                 num_wr_checks: Unsigned = NUM_WR_CHECKS,
+                 num_wr_successes: Unsigned = NUM_WR_SUCCESSES):
         """
         Instantiate the `PineValid` circuit for gradients with `dimension`
         elements. Each element will be truncated to `num_frac_bits` binary
@@ -56,6 +59,9 @@ class PineValid(Valid):
         self.l2_norm_bound = l2_norm_bound
         self.num_frac_bits = num_frac_bits
         self.dimension = dimension
+        self.alpha = alpha
+        self.num_wr_checks = num_wr_checks
+        self.num_wr_successes = num_wr_successes
         encoded_norm_bound_unsigned = \
             self.encode_f64_into_field(l2_norm_bound).as_unsigned()
         if (self.Field.MODULUS / encoded_norm_bound_unsigned
@@ -79,12 +85,13 @@ class PineValid(Valid):
         # in the PINE paper.
 
         # Wraparound check bound, equal to the smallest power of two
-        # larger than or equal to `ALPHA * encoded_norm_bound_unsigned
+        # larger than or equal to `ceil(alpha * encoded_norm_bound_unsigned)
         # + 1` is a power of 2. Using a power of 2 allows us to use
         # the optimization of Remark 3.2 without degrading
         # completeness.
         self.wr_check_bound = self.Field(
-            next_power_of_2(ALPHA * encoded_norm_bound_unsigned + 1) - 1
+            next_power_of_2(math.ceil(alpha * encoded_norm_bound_unsigned) + 1)
+            - 1
         )
 
         # Number of bits to represent each wraparound check result, which
@@ -106,13 +113,13 @@ class PineValid(Valid):
         # - The success bit for each wraparound check
         self.bit_checked_len = \
             2 * self.num_bits_for_sq_norm + \
-            (self.num_bits_for_wr_check + 1) * NUM_WR_CHECKS
+            (self.num_bits_for_wr_check + 1) * num_wr_checks
 
         # Set `Valid` parameters.
         # The measurement length expected by `Flp.eval()` contains the encoded
         # gradient, the expected bits, and the dot products in wraparound
         # checks.
-        self.MEAS_LEN = dimension + self.bit_checked_len + NUM_WR_CHECKS
+        self.MEAS_LEN = dimension + self.bit_checked_len + num_wr_checks
         # 1 for bit check, 1 for wraparound check, 1 for final reduction.
         # Note we don't include the number of wraparound joint randomness field
         # elements in `JOINT_RAND_LEN`.
@@ -123,7 +130,7 @@ class PineValid(Valid):
         self.GADGET_CALLS = [
             chunk_count(chunk_length, self.bit_checked_len) + \
             chunk_count(chunk_length, dimension) + \
-            chunk_count(chunk_length, NUM_WR_CHECKS)
+            chunk_count(chunk_length, num_wr_checks)
         ]
         self.GADGETS = [ParallelSum(Mul(), chunk_length)]
 
@@ -166,7 +173,7 @@ class PineValid(Valid):
         rest = meas
         (encoded_gradient, rest) = front(self.dimension, rest)
         (bit_checked, rest) = front(self.bit_checked_len, rest)
-        (wr_check_results, rest) = front(NUM_WR_CHECKS, rest)
+        (wr_check_results, rest) = front(self.num_wr_checks, rest)
         assert len(rest) == 0
 
         rest = bit_checked
@@ -282,7 +289,7 @@ class PineValid(Valid):
         wr_success_count = self.Field(0)
         r_power = self.Field(1)
 
-        for i in range(NUM_WR_CHECKS):
+        for i in range(self.num_wr_checks):
             wr_check_v = self.Field.decode_from_bit_vector(wr_check_v_bits[i])
             computed_result = wr_check_v - self.wr_check_bound * shares_inv
 
@@ -306,7 +313,7 @@ class PineValid(Valid):
 
         return (
             self.parallel_sum(mul_inputs),
-            wr_success_count - self.Field(NUM_WR_SUCCESSES) * shares_inv
+            wr_success_count - self.Field(self.num_wr_successes) * shares_inv
         )
 
     def parallel_sum(self, mul_inputs):
@@ -370,9 +377,9 @@ class PineValid(Valid):
         a time rather than pre-compute the entire bufferr.
         """
         xof_output = wr_joint_rand_xof.next(
-            chunk_count(4, NUM_WR_CHECKS * self.dimension))
+            chunk_count(4, self.num_wr_checks * self.dimension))
 
-        wr_check_results = [self.Field(0)] * NUM_WR_CHECKS
+        wr_check_results = [self.Field(0)] * self.num_wr_checks
         for i, rand_bits in enumerate(bit_chunks(xof_output, 2)):
             wr_check_index = i // self.dimension
             x = encoded_gradient[i % self.dimension]
@@ -402,12 +409,12 @@ class PineValid(Valid):
         wr_check_bits = []
 
         # Number of successful checks. If the prover has passed more than
-        # `NUM_WR_SUCCESSES`, don't set the success bit to be 1 anymore,
-        # because verifier will check that exactly `NUM_WR_SUCCESSES` checks
-        # passed.
+        # `self.num_wr_successes`, don't set the success bit to be 1 anymore,
+        # because verifier will check that exactly `self.num_wr_successes`
+        # checks passed.
         wr_success_count = 0
 
-        for i in range(NUM_WR_CHECKS):
+        for i in range(self.num_wr_checks):
             # This wraparound check passes if the current dot product is in
             # range `[-wr_check_bound, wr_check_bound+1]`. To prove this, the
             # prover sends the bit-encoding of `wr_check_v =
@@ -420,10 +427,10 @@ class PineValid(Valid):
                 self.wr_check_bound + self.Field(1),
             )
 
-            if is_in_range and wr_success_count < NUM_WR_SUCCESSES:
+            if is_in_range and wr_success_count < self.num_wr_successes:
                 # If the result of the current wraparound check is
                 # in range, and the number of passing checks hasn't
-                # reached `NUM_WR_SUCCESSES`. Set the success bit
+                # reached `self.num_wr_successes`. Set the success bit
                 # to be 1.
                 wr_success_count += 1
                 wr_check_g = self.Field(1)
@@ -437,9 +444,9 @@ class PineValid(Valid):
             )
             wr_check_bits.append(wr_check_g)
 
-        # Sanity check the Client has passed `NUM_WR_SUCCESSES`
+        # Sanity check the Client has passed `self.num_wr_successes`
         # number of checks, otherwise Client SHOULD retry.
-        if wr_success_count != NUM_WR_SUCCESSES:
+        if wr_success_count != self.num_wr_successes:
             raise Exception(
                 "Client should retry wraparound check with "
                 "different wraparound joint randomness."
@@ -482,9 +489,9 @@ class PineValid(Valid):
         test_vec["dimension"] = self.dimension
         test_vec["chunk_length"] = self.chunk_length
         test_vec["field"] = self.Field.__name__
-        test_vec["num_wr_checks"] = NUM_WR_CHECKS
-        test_vec["num_wr_successes"] = NUM_WR_SUCCESSES
-        test_vec["alpha"] = ALPHA
+        test_vec["num_wr_checks"] = self.num_wr_checks
+        test_vec["num_wr_successes"] = self.num_wr_successes
+        test_vec["alpha"] = self.alpha
         return ["l2_norm_bound", "num_frac_bits", "dimension", "field",
                 "num_wr_checks", "num_wr_successes", "alpha"]
 

--- a/poc/vdaf_pine.py
+++ b/poc/vdaf_pine.py
@@ -11,7 +11,7 @@ from common import (Unsigned, byte, concat, front, to_be_bytes,
                     vec_add, vec_sub, zeros)
 from field import Field, Field128, Field64
 from flp_generic import FlpGeneric
-from flp_pine import PineValid, NUM_WR_CHECKS, NUM_WR_SUCCESSES
+from flp_pine import PineValid, ALPHA, NUM_WR_CHECKS, NUM_WR_SUCCESSES
 from vdaf import Vdaf
 from vdaf_prio3 import (
     USAGE_MEAS_SHARE, USAGE_PROOF_SHARE, USAGE_JOINT_RANDOMNESS,
@@ -100,12 +100,21 @@ class Pine(Vdaf):
                     chunk_length: Unsigned,
                     num_shares: Unsigned,
                     field: Field,
-                    num_proofs: Unsigned):
+                    num_proofs: Unsigned,
+                    alpha: float = ALPHA,
+                    num_wr_checks: Unsigned = NUM_WR_CHECKS,
+                    num_wr_successes: Unsigned = NUM_WR_SUCCESSES):
         class PineWithParams(Pine):
             # TODO(issue#39) Decide how many proofs to use and enforce
             # robustness.
             Flp = FlpGeneric(PineValid.with_field(field)(
-                l2_norm_bound, num_frac_bits, dimension, chunk_length
+                l2_norm_bound = l2_norm_bound,
+                num_frac_bits = num_frac_bits,
+                dimension = dimension,
+                chunk_length = chunk_length,
+                alpha = alpha,
+                num_wr_checks = num_wr_checks,
+                num_wr_successes = num_wr_successes
             ))
             PROOFS = num_proofs
             MEAS_LEN = Flp.MEAS_LEN - NUM_WR_CHECKS
@@ -677,14 +686,20 @@ class Pine128(Pine):
                     num_frac_bits: Unsigned,
                     dimension: Unsigned,
                     chunk_length: Unsigned,
-                    num_shares: Unsigned):
+                    num_shares: Unsigned,
+                    alpha: float = ALPHA,
+                    num_wr_checks: Unsigned = NUM_WR_CHECKS,
+                    num_wr_successes: Unsigned = NUM_WR_SUCCESSES):
         return super().with_params(l2_norm_bound = l2_norm_bound,
                                    num_frac_bits = num_frac_bits,
                                    dimension = dimension,
                                    chunk_length = chunk_length,
                                    num_shares = num_shares,
                                    field = Field128,
-                                   num_proofs = 1)
+                                   num_proofs = 1,
+                                   alpha = alpha,
+                                   num_wr_checks = num_wr_checks,
+                                   num_wr_successes = num_wr_successes)
 
 
 # `Pine` with `Field64` and three proofs.
@@ -695,11 +710,17 @@ class Pine64(Pine):
                     num_frac_bits: Unsigned,
                     dimension: Unsigned,
                     chunk_length: Unsigned,
-                    num_shares: Unsigned):
+                    num_shares: Unsigned,
+                    alpha: float = ALPHA,
+                    num_wr_checks: Unsigned = NUM_WR_CHECKS,
+                    num_wr_successes: Unsigned = NUM_WR_SUCCESSES):
         return super().with_params(l2_norm_bound = l2_norm_bound,
                                    num_frac_bits = num_frac_bits,
                                    dimension = dimension,
                                    chunk_length = chunk_length,
                                    num_shares = num_shares,
                                    field = Field64,
-                                   num_proofs = 3)
+                                   num_proofs = 3,
+                                   alpha = alpha,
+                                   num_wr_checks = num_wr_checks,
+                                   num_wr_successes = num_wr_successes)


### PR DESCRIPTION
Change tau to r_succ since r_succ is the ultimate value that determines ZK error and soundness error.
Reuse code in PineValid to compute the number of bits needed for wraparound checks in find_wr_params.sage script.
Print parameters into a table, so it's easier to view and we may put it into the draft.