### PR TITLE
Add unit tests for wraparound and squared norm bounds

### DIFF
--- a/poc/flp_pine.py
+++ b/poc/flp_pine.py
@@ -33,12 +33,12 @@ class PineValid(Valid):
 
     def __init__(self,
                  l2_norm_bound: float,
-                 num_frac_bits: Unsigned,
-                 dimension: Unsigned,
-                 chunk_length: Unsigned = None,
+                 num_frac_bits: int,
+                 dimension: int,
+                 chunk_length: int,
                  alpha: float = ALPHA,
-                 num_wr_checks: Unsigned = NUM_WR_CHECKS,
-                 num_wr_successes: Unsigned = NUM_WR_SUCCESSES):
+                 num_wr_checks: int = NUM_WR_CHECKS,
+                 num_wr_successes: int = NUM_WR_SUCCESSES):
         """
         Instantiate the `PineValid` circuit for gradients with `dimension`
         elements. Each element will be truncated to `num_frac_bits` binary

--- a/poc/flp_pine_test.py
+++ b/poc/flp_pine_test.py
@@ -9,7 +9,8 @@ dir_name = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.join(dir_name, "draft-irtf-cfrg-vdaf", "poc"))
 
 from common import gen_rand
-from flp_pine import PineValid, bit_chunks
+from flp_pine import PineValid, bit_chunks, ALPHA, NUM_WR_CHECKS, \
+    NUM_WR_SUCCESSES
 from field import Field64, Field128
 from flp_generic import FlpGeneric, test_flp_generic
 
@@ -82,6 +83,87 @@ class TestEncoding(unittest.TestCase):
                 1
             )
         )
+
+
+class TestOperationalParameters(unittest.TestCase):
+
+    def test_bounds(self):
+        """
+        Test bound computatinos (squared norm and wraparound checks) for
+        various parameters and the default alpha, number of wraparound tests,
+        and number of successes.
+        """
+
+        Valid = PineValid.with_field(Field128)
+
+        test_cases = [
+            {
+                "l2_norm_bound": 1.0,
+                "num_frac_bits": 15,
+                "expected_sq_norm_bound": Field128(1073741824),
+                "expected_num_bits_for_sq_norm": 31,
+                "expected_wr_check_bound": Field128(524287),
+                "expected_num_bits_for_wr_check": 20,
+            },
+            {
+                "l2_norm_bound": 1.0,
+                "num_frac_bits": 24,
+                "expected_sq_norm_bound": Field128(281474976710656),
+                "expected_num_bits_for_sq_norm": 49,
+                "expected_wr_check_bound": Field128(268435455),
+                "expected_num_bits_for_wr_check": 29,
+            },
+            {
+                "l2_norm_bound": 1000.0,
+                "num_frac_bits": 15,
+                "expected_sq_norm_bound": Field128(1073741824000000),
+                "expected_num_bits_for_sq_norm": 50,
+                "expected_wr_check_bound": Field128(536870911),
+                "expected_num_bits_for_wr_check": 30,
+            },
+            {
+                "l2_norm_bound": 0.0001,
+                "num_frac_bits": 15,
+                "expected_sq_norm_bound": Field128(9),
+                "expected_num_bits_for_sq_norm": 4,
+                "expected_wr_check_bound": Field128(31),
+                "expected_num_bits_for_wr_check": 6,
+            },
+            {
+                "l2_norm_bound": 1.0,
+                "num_frac_bits": 0,
+                "expected_sq_norm_bound": Field128(1),
+                "expected_num_bits_for_sq_norm": 1,
+                "expected_wr_check_bound": Field128(15),
+                "expected_num_bits_for_wr_check": 5,
+            },
+            {
+                "l2_norm_bound": 1337.0,
+                "num_frac_bits": 0,
+                "expected_sq_norm_bound": Field128(1787569),
+                "expected_num_bits_for_sq_norm": 21,
+                "expected_wr_check_bound": Field128(16383),
+                "expected_num_bits_for_wr_check": 15,
+            },
+        ]
+
+        for t in test_cases:
+            # The dimension and chunk_length don't impact these tests.
+            v = Valid(t["l2_norm_bound"], t["num_frac_bits"], 10000, 123)
+            self.assertEqual(v.alpha, ALPHA)
+            self.assertEqual(v.num_wr_checks, NUM_WR_CHECKS)
+            self.assertEqual(v.num_wr_successes, NUM_WR_SUCCESSES)
+            self.assertEqual(v.l2_norm_bound, t["l2_norm_bound"])
+            self.assertEqual(v.num_frac_bits, t["num_frac_bits"])
+            self.assertEqual(v.dimension, 10000)
+            self.assertEqual(v.chunk_length, 123)
+            self.assertEqual(v.encoded_sq_norm_bound,
+                             t["expected_sq_norm_bound"])
+            self.assertEqual(v.num_bits_for_sq_norm,
+                             t["expected_num_bits_for_sq_norm"])
+            self.assertEqual(v.wr_check_bound, t["expected_wr_check_bound"])
+            self.assertEqual(v.num_bits_for_wr_check,
+                             t["expected_num_bits_for_wr_check"])
 
 
 class TestCircuit(unittest.TestCase):


### PR DESCRIPTION
Stacked on #74.

Also, clean up the parameters of `PineValid()`.