### PR TITLE
Define Pine48 and change the number of proofs for Pine64

### DIFF
--- a/poc/field_pine.py
+++ b/poc/field_pine.py
@@ -1,0 +1,16 @@
+from sage.all import GF
+from field import FftField
+
+class Field48(FftField):
+    """The finite field GF(2^21 * 3^2 * 14913079 + 1)."""
+
+    MODULUS = 2**21 * 3**2 * 14913079 + 1
+    GEN_ORDER = 2**21
+    ENCODED_SIZE = 6
+
+    # Operational parameters
+    gf = GF(MODULUS)
+
+    @classmethod
+    def gen(cls):
+        return cls(cls.gf.primitive_element()**(3**2 * 14913079))

--- a/poc/vdaf_pine.py
+++ b/poc/vdaf_pine.py
@@ -10,6 +10,7 @@ sys.path.append(os.path.join(dir_name, "draft-irtf-cfrg-vdaf", "poc"))
 from common import (Unsigned, byte, concat, front, to_be_bytes,
                     vec_add, vec_sub, zeros)
 from field import Field, Field128, Field64
+from field_pine import Field48
 from flp_generic import FlpGeneric
 from flp_pine import PineValid, ALPHA, NUM_WR_CHECKS, NUM_WR_SUCCESSES
 from vdaf import Vdaf
@@ -722,6 +723,29 @@ class Pine64(Pine):
                                    chunk_length = chunk_length,
                                    num_shares = num_shares,
                                    field = Field64,
+                                   num_proofs = 2,
+                                   alpha = alpha,
+                                   num_wr_checks = num_wr_checks,
+                                   num_wr_successes = num_wr_successes)
+
+
+class Pine48(Pine):
+    @classmethod
+    def with_params(cls,
+                    l2_norm_bound,
+                    num_frac_bits,
+                    dimension,
+                    chunk_length,
+                    num_shares,
+                    alpha = ALPHA,
+                    num_wr_checks = NUM_WR_CHECKS,
+                    num_wr_successes = NUM_WR_SUCCESSES):
+        return super().with_params(l2_norm_bound,
+                                   num_frac_bits,
+                                   dimension,
+                                   chunk_length,
+                                   num_shares = num_shares,
+                                   field = Field48,
                                    num_proofs = 3,
                                    alpha = alpha,
                                    num_wr_checks = num_wr_checks,

--- a/poc/vdaf_pine_test.py
+++ b/poc/vdaf_pine_test.py
@@ -10,7 +10,7 @@ sys.path.append(os.path.join(dir_name, "draft-irtf-cfrg-vdaf", "poc"))
 from common import TEST_VECTOR, gen_rand
 from field import Field64, Field128
 from vdaf import test_vdaf
-from vdaf_pine import Pine, Pine128, Pine64, VERSION
+from vdaf_pine import Pine, Field48, Pine128, Pine48, Pine64, VERSION
 from vdaf_prio3 import (
     USAGE_MEAS_SHARE, USAGE_PROOF_SHARE, USAGE_JOINT_RANDOMNESS,
     USAGE_PROVE_RANDOMNESS, USAGE_QUERY_RANDOMNESS, USAGE_JOINT_RAND_SEED,
@@ -90,7 +90,16 @@ class TestPineVdafEndToEnd(unittest.TestCase):
             test_vec_instance=pine.Flp.Valid.Field.__name__
         )
 
-    def test_field64_three_proofs(self):
+    def test_field48(self):
+        pine = Pine48.with_params(l2_norm_bound = self.l2_norm_bound,
+                                  dimension = self.dimension,
+                                  num_frac_bits = self.num_frac_bits,
+                                  chunk_length = self.chunk_length,
+                                  num_shares = self.num_shares)
+        self.assertEqual(pine.Flp.Field, Field48)
+        self.run_pine_vdaf(pine)
+
+    def test_field64(self):
         pine = Pine64.with_params(l2_norm_bound = self.l2_norm_bound,
                                   dimension = self.dimension,
                                   num_frac_bits = self.num_frac_bits,
@@ -99,7 +108,7 @@ class TestPineVdafEndToEnd(unittest.TestCase):
         self.assertEqual(pine.Flp.Field, Field64)
         self.run_pine_vdaf(pine)
 
-    def test_field128_one_proof(self):
+    def test_field128(self):
         pine = Pine128.with_params(l2_norm_bound = self.l2_norm_bound,
                                    dimension = self.dimension,
                                    num_frac_bits = self.num_frac_bits,


### PR DESCRIPTION
Pine48 has three proofs and a 48-bit field. Not accounting for offline attacks, our current estimate suggests this yields at least 100 bits of security.

Based on the same estimate, only two proofs are required to achieve the same level of security for Pine64.