### PR TITLE
Change the number of proofs for Pine64 from 3 to 2

### DIFF
--- a/poc/vdaf_pine.py
+++ b/poc/vdaf_pine.py
@@ -722,7 +722,7 @@ class Pine64(Pine):
                                    chunk_length = chunk_length,
                                    num_shares = num_shares,
                                    field = Field64,
-                                   num_proofs = 3,
+                                   num_proofs = 2,
                                    alpha = alpha,
                                    num_wr_checks = num_wr_checks,
                                    num_wr_successes = num_wr_successes)

--- a/poc/vdaf_pine_test.py
+++ b/poc/vdaf_pine_test.py
@@ -90,7 +90,7 @@ class TestPineVdafEndToEnd(unittest.TestCase):
             test_vec_instance=pine.Flp.Valid.Field.__name__
         )
 
-    def test_field64_three_proofs(self):
+    def test_field64(self):
         pine = Pine64.with_params(l2_norm_bound = self.l2_norm_bound,
                                   dimension = self.dimension,
                                   num_frac_bits = self.num_frac_bits,
@@ -99,7 +99,7 @@ class TestPineVdafEndToEnd(unittest.TestCase):
         self.assertEqual(pine.Flp.Field, Field64)
         self.run_pine_vdaf(pine)
 
-    def test_field128_one_proof(self):
+    def test_field128(self):
         pine = Pine128.with_params(l2_norm_bound = self.l2_norm_bound,
                                    dimension = self.dimension,
                                    num_frac_bits = self.num_frac_bits,


### PR DESCRIPTION
Based on our current estimate, two proofs are sufficient to achieve 100 bits of security.