### PR TITLE
Make sure l2_norm_bound is not negative

### DIFF
--- a/poc/flp_pine_test.py
+++ b/poc/flp_pine_test.py
@@ -64,13 +64,13 @@ class TestEncoding(unittest.TestCase):
             },
         ]
         for (i, t) in enumerate(test_cases):
-            encoded = valid.encode_f64_into_field(t["input"])
+            encoded = valid.encode_float_into_field(t["input"])
             if t["input"] < 0:
                 # Negative values are represented with the upper half of the
                 # field bits.
                 self.assertTrue(
                     encoded.as_unsigned() > math.floor(valid.Field.MODULUS/2))
-            decoded = valid.decode_f64_from_field(encoded)
+            decoded = valid.decode_float_from_field(encoded)
             self.assertEqual(decoded, t["expected_result"])
 
     def test_roundtrip_gradient(self):


### PR DESCRIPTION
The upper bits of the field are used for negative numbers. If l2_norm_bound is larger than the field modulus divided by 2, then it will be interpreted as a negative number.

Also rename `encode_f64_into_field()` to `encode_float_into_field()` since Python doesn't have an f64 type.