### PR TITLE
Align reference code with draft-irtf-cfrg-vdaf-10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         submodules: true
 
     - name: Install dependencies
-      run: sage --pip install pycryptodomex
+      run: sage -pip install git+https://github.com/cfrg/draft-irtf-cfrg-vdaf@fefc5a2f563e70e73a74d3c57b7145e0dd1c2e3f#subdirectory=poc
 
     - name: Run tests
       working-directory: poc

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "draft-irtf-cfrg-vdaf"]
-	path = poc/draft-irtf-cfrg-vdaf
-	url = https://github.com/cfrg/draft-irtf-cfrg-vdaf


### PR DESCRIPTION
We need https://github.com/cfrg/draft-irtf-cfrg-vdaf/pull/383 before we can merge this.

Remove the submodule and require the user to install the reference code the VDAF draft via pip:

```
sage -pip install git+https://github.com/cfrg/draft-irtf-cfrg-vdaf@72227878#subdirectory=poc
```

This installs a package `vdaf_poc` that can be imported from PINE. Hacking in the module by adding the submodule to Python's PATH is no longer necessary.

- Replace class-factory patterns with standard Python OOP patterns. In particular, methods on `Vdaf` are no longer class methods, but methods on an instance of the class that is constructed with all the necessary parameters.

Enforce type hints:

```
sage -python -m mypy *pine*.py
```

This required minor changes to the code in some cases. For instance, previously we allowed `chunk_length` to be `None`, but the type is `int`, not `Optional[int]`. There are also situations where it's necessary to call `cast()` to tell the type checker that an `Optional[SomeType]` is a `SomeType` and not `None`.

Another notable change is that, in some cases, we were treating generic types as class constructors. In particular, we often want to be generic in the finite field, but then invoke the constructor for that type with the same variable. Python's type hints doesn't actually support this.

Finally, rename `encode_gradient_and_norm()` to `encode()`, which is an abstract method of `Flp`. This was pointed out by the type checker.