### PR TITLE
Add GitHub Actions for linting and type checking

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -1,0 +1,40 @@
+name: Lint Python
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - '.github/workflows/lint-python.yml'
+    - 'poc/**'
+  pull_request:
+    paths:
+    - '.github/workflows/lint-python.yml'
+    - 'poc/**'
+
+jobs:
+  test:
+    name: "Check formatting"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Install tools
+      run: pip install pyflakes autopep8 isort pylint
+
+    - name: Run pyflakes
+      working-directory: poc
+      run: pyflakes *.py tests/*.py
+
+    - name: Run autopep8
+      working-directory: poc
+      run: autopep8 --diff --exit-code *.py tests/*.py
+
+    - name: Run isort
+      working-directory: poc
+      run: isort --check .
+
+    - name: Run pylint
+      working-directory: poc
+      run: pylint --disable=all --enable=redefined-outer-name *.py tests/*.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,21 +19,25 @@ jobs:
     container:
       image: sagemath/sagemath:latest
       options: --user root
-
     steps:
-    - name: Install git on container
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Install git
       run: |
         apt update
         apt install -y git
 
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        submodules: true
-
+      # TODO Point to tag draft-irtf-cfrg-vdaf-11 when it's available.
     - name: Install dependencies
-      run: sage -pip install git+https://github.com/cfrg/draft-irtf-cfrg-vdaf@fefc5a2f563e70e73a74d3c57b7145e0dd1c2e3f#subdirectory=poc
+      run: |
+        sage -pip install mypy
+        sage -pip install git+https://github.com/cfrg/draft-irtf-cfrg-vdaf@fefc5a2f563e70e73a74d3c57b7145e0dd1c2e3f#subdirectory=poc
 
     - name: Run tests
       working-directory: poc
-      run: sage -python -m unittest *_test.py
+      run: sage -python -m unittest
+
+    - name: Enforce type hints
+      working-directory: poc
+      run: sage -python -m mypy *.py tests/*.py

--- a/poc/Makefile
+++ b/poc/Makefile
@@ -1,3 +1,2 @@
 all:
-	sage -python flp_pine_test.py
-	sage -python vdaf_pine_test.py
+	sage -python -m unittest

--- a/poc/generate_test_vectors.sh
+++ b/poc/generate_test_vectors.sh
@@ -1,3 +1,3 @@
 version=`cat VERSION`
 echo "PINE version: ${version}"
-TEST_VECTOR=TRUE TEST_VECTOR_PATH=test_vec/$(printf "%02d" $version) sage -python vdaf_pine_test.py
+TEST_VECTOR=TRUE TEST_VECTOR_PATH=test_vec/$(printf "%02d" $version) sage -python -m unittest tests/test_vdaf.py

--- a/poc/tests/test_flp.py
+++ b/poc/tests/test_flp.py
@@ -2,16 +2,15 @@
 
 import math
 import os
-import sys
 import unittest
-
-from flp_pine import (PineValid, bit_chunks, ALPHA, NUM_WR_CHECKS,
-                      NUM_WR_SUCCESSES, encode_float)
 
 from vdaf_poc.common import gen_rand
 from vdaf_poc.field import Field64, Field128
 from vdaf_poc.flp_bbcggi19 import FlpBBCGGI19, test_flp_bbcggi19
 from vdaf_poc.xof import XofTurboShake128
+
+from flp_pine import (ALPHA, NUM_WR_CHECKS, NUM_WR_SUCCESSES, PineValid,
+                      bit_chunks, encode_float)
 
 
 class TestEncoding(unittest.TestCase):
@@ -145,9 +144,11 @@ class TestOperationalParameters(unittest.TestCase):
         ]
 
         for t in test_cases:
-            l2_norm_bound = encode_float(t["l2_norm_bound"], t["num_frac_bits"])
+            l2_norm_bound = encode_float(
+                t["l2_norm_bound"], t["num_frac_bits"])
             # The dimension and chunk_length don't impact these tests.
-            v = PineValid(Field128, l2_norm_bound, t["num_frac_bits"], 10000, 123)
+            v = PineValid(Field128, l2_norm_bound,
+                          t["num_frac_bits"], 10000, 123)
             self.assertEqual(v.alpha, ALPHA)
             self.assertEqual(v.num_wr_checks, NUM_WR_CHECKS)
             self.assertEqual(v.num_wr_successes, NUM_WR_SUCCESSES)
@@ -209,7 +210,8 @@ class TestOperationalParameters(unittest.TestCase):
 
         for t in test_cases:
             alpha = t.get("alpha", ALPHA)
-            l2_norm_bound = encode_float(t["l2_norm_bound"], t["num_frac_bits"])
+            l2_norm_bound = encode_float(
+                t["l2_norm_bound"], t["num_frac_bits"])
             # The dimension and chunk_length don't impact these tests.
             if t["expected_success"]:
                 v = PineValid(t["field"], l2_norm_bound, t["num_frac_bits"],

--- a/poc/tests/test_vdaf.py
+++ b/poc/tests/test_vdaf.py
@@ -1,21 +1,17 @@
 """Unit tests for PINE VDAF. """
 
-import math
-import os
-import sys
 import unittest
 
 from vdaf_poc.common import TEST_VECTOR, gen_rand
 from vdaf_poc.field import Field64, Field128
 from vdaf_poc.vdaf import test_vdaf
-from vdaf_poc.vdaf_prio3 import (
-    USAGE_MEAS_SHARE, USAGE_PROOF_SHARE, USAGE_JOINT_RANDOMNESS,
-    USAGE_PROVE_RANDOMNESS, USAGE_QUERY_RANDOMNESS, USAGE_JOINT_RAND_SEED,
-    USAGE_JOINT_RAND_PART
-)
+from vdaf_poc.vdaf_prio3 import (USAGE_JOINT_RAND_PART, USAGE_JOINT_RAND_SEED,
+                                 USAGE_JOINT_RANDOMNESS, USAGE_MEAS_SHARE,
+                                 USAGE_PROOF_SHARE, USAGE_PROVE_RANDOMNESS,
+                                 USAGE_QUERY_RANDOMNESS)
 
-from flp_pine import PineValid, encode_float
-from vdaf_pine import Pine, Pine128, Pine64, VERSION
+from flp_pine import encode_float
+from vdaf_pine import Pine64, Pine128
 
 
 class TestDomainSeparationTag(unittest.TestCase):
@@ -40,11 +36,11 @@ class TestShard(unittest.TestCase):
 
     def test_result_share_length(self):
         """Check the result shares of `shard()` have the expected lengths. """
-        pine = Pine64(l2_norm_bound = encode_float(1.0, 4),
-                      num_frac_bits = 4,
-                      dimension = 4,
-                      chunk_length = 150,
-                      num_shares = 2)
+        pine = Pine64(l2_norm_bound=encode_float(1.0, 4),
+                      num_frac_bits=4,
+                      dimension=4,
+                      chunk_length=150,
+                      num_shares=2)
         measurement = [0.0] * pine.valid.dimension
         nonce = gen_rand(pine.NONCE_SIZE)
         rand = gen_rand(pine.RAND_SIZE)
@@ -82,7 +78,8 @@ class TestPineVdafEndToEnd(unittest.TestCase):
         measurement_1[0] = 1.0
         measurement_2 = [0.0] * pine.valid.dimension
         measurement_2[1] = 1.0
-        expected_agg_result = [x + y for (x, y) in zip(measurement_1, measurement_2)]
+        expected_agg_result = [
+            x + y for (x, y) in zip(measurement_1, measurement_2)]
         test_vdaf(
             pine,
             None,
@@ -93,20 +90,20 @@ class TestPineVdafEndToEnd(unittest.TestCase):
         )
 
     def test_field64(self):
-        pine = Pine64(l2_norm_bound = self.l2_norm_bound,
-                      dimension = self.dimension,
-                      num_frac_bits = self.num_frac_bits,
-                      chunk_length = self.chunk_length,
-                      num_shares = self.num_shares)
+        pine = Pine64(l2_norm_bound=self.l2_norm_bound,
+                      dimension=self.dimension,
+                      num_frac_bits=self.num_frac_bits,
+                      chunk_length=self.chunk_length,
+                      num_shares=self.num_shares)
         self.assertEqual(pine.flp.field, Field64)
         self.run_pine_vdaf(pine)
 
     def test_field128(self):
-        pine = Pine128(l2_norm_bound = self.l2_norm_bound,
-                       dimension = self.dimension,
-                       num_frac_bits = self.num_frac_bits,
-                       chunk_length = self.chunk_length,
-                       num_shares = self.num_shares)
+        pine = Pine128(l2_norm_bound=self.l2_norm_bound,
+                       dimension=self.dimension,
+                       num_frac_bits=self.num_frac_bits,
+                       chunk_length=self.chunk_length,
+                       num_shares=self.num_shares)
         self.assertEqual(pine.flp.field, Field128)
         self.run_pine_vdaf(pine)
 


### PR DESCRIPTION
Closes #75.
Based on #90 (merge that first).

Also, put the tests in a module so that we can use the unittest module to invoke the unit tests.