### PR TITLE
switch rounding mode to "round to nearest, ties to even"

### DIFF
--- a/poc/flp_pine.py
+++ b/poc/flp_pine.py
@@ -616,7 +616,7 @@ def chunk_count(chunk_length, length):
 
 
 def encode_float(x: float, num_frac_bits: int) -> int:
-    return math.floor(x * 2**num_frac_bits)
+    return round(x * 2**num_frac_bits)
 
 
 def construct_circuits(

--- a/poc/tests/test_flp.py
+++ b/poc/tests/test_flp.py
@@ -28,7 +28,7 @@ class TestEncoding(unittest.TestCase):
             },
             {
                 "input": -0.0001,
-                "expected_result": -0.0001220703125,
+                "expected_result": -9.1552734375e-05,
             },
             {
                 "input": -0.0,
@@ -44,7 +44,7 @@ class TestEncoding(unittest.TestCase):
             },
             {
                 "input": 0.1,
-                "expected_result": 0.0999755859375,
+                "expected_result": 0.100006103515625,
             },
             {
                 "input": 0.5,


### PR DESCRIPTION
# Why

Currently we use round to $-\infty $ and this can introduce more rounding error than the IEEE 754 default rounding mode, i.e. "round to nearest, ties to even".  e.g.

input =-0.0001 

current: output=-0.0001220703125, relative error = 0.22
new=-9.1552734375e-05, relative error = 0.084

( this is taken from one of the test cases)

# What

Switch to "round to nearest, ties to even" mode


# Discussion

Test vector is actually not affected since we use either 0.0 or 1.0 as inputs, which convert to same integer with both modes.
